### PR TITLE
Add sentry and posthog to config.ru

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -6,8 +6,13 @@ if ENV['RACK_ENV'] != 'production'
   require 'pry'
 end
 
+use_sentry = !ENV['SENTRY_DSN'].nil?
+use_posthog = !ENV['POSTHOG_API_KEY'].nil?
+
 require 'rubygems'
 require 'bundler'
+
+require 'raven' if use_sentry
 
 Bundler.require
 
@@ -27,6 +32,8 @@ if ENV['RACK_ENV'] == 'production'
 end
 
 app = Rack::Builder.new do
+  use Raven::Rack if use_sentry
+
   use Rack::Cors do
     allow do
       origins '*'

--- a/config.ru
+++ b/config.ru
@@ -7,7 +7,6 @@ if ENV['RACK_ENV'] != 'production'
 end
 
 use_sentry = !ENV['SENTRY_DSN'].nil?
-use_posthog = !ENV['POSTHOG_API_KEY'].nil?
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
We need some more visibility into the instances we are deploying. This may be temp, or somehow only added to paid plans, but as is wont start indiscriminately sending us events and errors for OSS deployments