### PR TITLE
Pin sinatra-activerecord

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
     - "dependencies"
     - "ruby"
     - "automerge"
+  ignore:
+    - dependency-name: "sinatra-activerecord"
+      versions: ["2.0.21"]

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'rake'
 gem 'sinatra'
 gem 'sentry-raven'
 
-gem 'sinatra-activerecord', '2.0.21'
+gem 'sinatra-activerecord', '2.0.20'
 
 group :test do
   gem 'database_cleaner-active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sinatra-activerecord (2.0.21)
+    sinatra-activerecord (2.0.20)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
     sinatra-contrib (2.1.0)
@@ -206,7 +206,7 @@ DEPENDENCIES
   sentry-raven
   simplecov (= 0.17)
   sinatra
-  sinatra-activerecord (= 2.0.21)
+  sinatra-activerecord (= 2.0.20)
   webmock (~> 3.10)
 
 RUBY VERSION


### PR DESCRIPTION
We failed to properly fix this automerge dependency so it happened again. now we are telling dependabot to specifically ignore this update