### PR TITLE
Dont let codeclimate block CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,6 +39,10 @@ steps:
   - name: ":codeclimate:"
     commands:
       - '.buildkite/report-coverage.sh'
+    soft_fail:
+      - exit_status: 1
+
+  - wait
 
   - name: ":broom:"
     commands: "yarn clean"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,8 +39,7 @@ steps:
   - name: ":codeclimate:"
     commands:
       - '.buildkite/report-coverage.sh'
-    soft_fail:
-      - exit_status: 1
+    soft_fail: true
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,8 +40,6 @@ steps:
     commands:
       - '.buildkite/report-coverage.sh'
 
-  - wait
-
   - name: ":broom:"
     commands: "yarn clean"
     branches: "main"


### PR DESCRIPTION
codeclimate released a broken version of their reporter - https://github.com/codeclimate/test-reporter/issues/449

this should allow the codecliemate step in our CI to fail without preventing the rest of the pipeline from executing